### PR TITLE
Feature reify characters

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -1,0 +1,13 @@
+class Character {
+  constructor() {
+    this.clips = {};
+    this.actions = {};
+  }
+
+  playAnimation(name, canvas) {
+    let animation = this.actions[name] || this.clips[name]
+    return animation && animation.play(canvas)
+  }
+};
+
+module.exports = Character;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ let Animation = require('./animation')
 let Scene = require('./scene')
 let State = require('./state')
 let Clip = require('./clip')
+let Character = require('./character')
 
 let $ = require('jquery')
 
@@ -41,6 +42,7 @@ function addImage(object, imageName, urlPrefix) {
 muvment.State = State;
 muvment.Scene = Scene;
 muvment.Clip = Clip;
+muvment.Character = Character;
 
 muvment.animation = {
   sequence: sequence,

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ describe ('muvment', () => {
   let { clip: clip1, spy: spy1 } = newClip("some/source", 10);
   let { clip: clip2, spy: spy2 } = newClip("some/other/source", 20);
   let { clip: clip3, spy: spy3 } = newClip("yet/another/source", 30);
+  let sequenceAnimation = muvment.animation.sequence([clip1, clip2, clip3]);
 
   beforeEach(() => {
     spy1.resetHistory();
@@ -22,12 +23,12 @@ describe ('muvment', () => {
 
   describe('Clip', () => {
     context('play', () => {
-      it('changes the image src', async () => {
-        let image = {};
+      it('changes the canvas src', async () => {
+        let canvas = {};
         
-        await new muvment.Clip('some/source', 10).play(image);
+        await new muvment.Clip('some/source', 10).play(canvas);
 
-        assert.equal(image.src, 'some/source');
+        assert.equal(canvas.src, 'some/source');
       });
     });
   });
@@ -35,9 +36,7 @@ describe ('muvment', () => {
   describe('Animation', () => {
     context('sequence', () => {
       it('plays every clip sequentially', async () => {
-        let animation = muvment.animation.sequence([clip1, clip2, clip3]);
-
-        await animation.play({});
+        await sequenceAnimation.play({});
 
         sinon.assert.callOrder(spy1, spy2, spy3);
       });
@@ -57,7 +56,7 @@ describe ('muvment', () => {
   describe('State', () => {
     context('play', () => {
       it('calls start and end callbacks before and after animation', async () => {
-        let state = muvment.animation.sequence([clip1, clip2, clip3]).asState();
+        let state = sequenceAnimation.asState();
 
         let stateStartSpy = sinon.spy();
         let stateEndSpy = sinon.spy();
@@ -68,6 +67,42 @@ describe ('muvment', () => {
         await state.play({});
 
         sinon.assert.callOrder(stateStartSpy, spy1, spy2, spy3, stateEndSpy);
+      });
+    });
+  });
+
+  describe('Character', () => {
+    context('playAnimation', () => {
+      it('plays an action if available', async () => {
+        let character = new muvment.Character();
+
+        character.actions = { run: sequenceAnimation }
+
+        await character.playAnimation('run', {});
+
+        sinon.assert.callOrder(spy1, spy2, spy3);
+      });
+
+      it('plays a clip if no action by that name', async () => {
+        let character = new muvment.Character();
+
+        character.clips = { run: clip1 }
+
+        await character.playAnimation('run', {});
+
+        sinon.assert.called(spy1);
+      });
+
+      it('does nothing if no actions or clips by that name', async () => {
+        let character = new muvment.Character();
+
+        character.actions = { run: sequenceAnimation }
+
+        assert.doesNotThrow(async () => { await character.playAnimation('run', {}) });
+
+        sinon.assert.notCalled(spy1);
+        sinon.assert.notCalled(spy2);
+        sinon.assert.notCalled(spy3);
       });
     });
   });


### PR DESCRIPTION
Right now to play an animation we're doing something like:
`mumuki.character.actions.talk.play(canvas)`

This PR is meant to both prevent breaking encapsulation when playing a character's animation, and prevent exceptions when trying to play an action / clip which does not exist for the character.

The above code would become:
`mumuki.character.playAnimation('talk', canvas)`