### PR TITLE
Feature relaxed content types

### DIFF
--- a/gem/muvment.gemspec
+++ b/gem/muvment.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.version       = Muvment::VERSION
 
-  spec.add_development_dependency 'bundler', '~> 1.16.a'
+  spec.add_development_dependency 'bundler', '>= 1.16', '< 3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 

--- a/src/animation.js
+++ b/src/animation.js
@@ -23,9 +23,9 @@ function sequence(clips) {
     let accum = Promise.resolve();
 
     clips.forEach((clip) =>
-      accum = accum.then(() => 
+      accum = accum.then(() =>
         clip.play(where)));
-    
+
     return accum;
   });
 }

--- a/src/animation.js
+++ b/src/animation.js
@@ -36,12 +36,20 @@ function oneOf(clips) {
   });
 }
 
+// Parses an XML value only if it is a string.
+// This is required in order to muvement work also
+// when character's ajax response does not expose a proper content-type
+function parseXmlIdNeeded(data) {
+  return typeof(data) === 'string' ? new DOMParser().parseFromString(data, "text/xml") : data;
+}
+
 function addImage(object, imageName, urlPrefix) {
   let url = urlPrefix + imageName + '.svg';
   if (object[imageName]) return Promise.resolve();
 
   return new Promise((resolve) => {
     $.get(url, (data) => {
+      data = parseXmlIdNeeded(data);
       let duration = parseFloat($(data).find('animate').attr('dur') || 0, 10) * 1000;
       object[imageName] = new Clip('data:image/svg+xml;base64,' + btoa(data.documentElement.outerHTML), duration);
       resolve();

--- a/src/animation.js
+++ b/src/animation.js
@@ -37,9 +37,9 @@ function oneOf(clips) {
 }
 
 // Parses an XML value only if it is a string.
-// This is required in order to muvement work also
+// This is required in order to make muvement work also
 // when character's ajax response does not expose a proper content-type
-function parseXmlIdNeeded(data) {
+function parseXmlIfNeeded(data) {
   return typeof(data) === 'string' ? new DOMParser().parseFromString(data, "text/xml") : data;
 }
 
@@ -49,7 +49,7 @@ function addImage(object, imageName, urlPrefix) {
 
   return new Promise((resolve) => {
     $.get(url, (data) => {
-      data = parseXmlIdNeeded(data);
+      data = parseXmlIfNeeded(data);
       let duration = parseFloat($(data).find('animate').attr('dur') || 0, 10) * 1000;
       object[imageName] = new Clip('data:image/svg+xml;base64,' + btoa(data.documentElement.outerHTML), duration);
       resolve();

--- a/src/load.js
+++ b/src/load.js
@@ -42,7 +42,7 @@ function loadCharacters(where, src){
   }
 
   // Parses a JSON value only if it is a string.
-  // This is required in order to muvement work also
+  // This is required in order to make muvement work also
   // when animations's ajax response does not expose a proper content-type
   function parseJsonIfNeeded(value) {
     return typeof(value) === 'string' ? JSON.parse(value) : value;

--- a/src/load.js
+++ b/src/load.js
@@ -43,7 +43,7 @@ function loadCharacters(where, src){
 
   // Parses a JSON value only if it is a string.
   // This is required in order to muvement work also
-  // when ajax response does not expose a proper content-type
+  // when animations's ajax response does not expose a proper content-type
   function parseJsonIfNeeded(value) {
     return typeof(value) === 'string' ? JSON.parse(value) : value;
   }

--- a/src/load.js
+++ b/src/load.js
@@ -41,10 +41,19 @@ function loadCharacters(where, src){
     return animation.addImage(where[character].clips, name, `/character/${character}/`);
   }
 
-  return $.get(src).then((animations) => {
-    loadAnimationGroup(animations.extra);
-    return loadAnimationGroup(animations.main);
-  });
+  // Parses a JSON value only if it is a string.
+  // This is required in order to muvement work also
+  // when ajax response does not expose a proper content-type
+  function parseJsonIfNeeded(value) {
+    return typeof(value) === 'string' ? JSON.parse(value) : value;
+  }
+
+  return $.get(src)
+          .then(parseJsonIfNeeded)
+          .then((animations) => {
+            loadAnimationGroup(animations.extra);
+            return loadAnimationGroup(animations.main);
+          });
 }
 
 module.exports = loadCharacters;


### PR DESCRIPTION
This PR makes `muvement` work also when `animations.json` and character files are not served with the proper `Content-Type` headers. 